### PR TITLE
Remoção indPag dos parâmetros

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -454,7 +454,6 @@ class Make
             'cUF',
             'cNF',
             'natOp',
-            'indPag',
             'mod',
             'serie',
             'nNF',
@@ -502,16 +501,6 @@ class Make
             true,
             $identificador . "Descrição da Natureza da Operação"
         );
-        //removido desta posição no layout 4.00
-        if ($this->version == '3.10') {
-            $this->dom->addChild(
-                $ide,
-                "indPag",
-                $std->indPag,
-                true,
-                $identificador . "Indicador da forma de pagamento"
-            );
-        }
         $this->dom->addChild(
             $ide,
             "mod",


### PR DESCRIPTION
Não seria necessário remover o indPag dos parâmetros para ficar em conformidade com a NF-e 4.0?
Deixando o indPag aqui, será necessário deixar o indPag para a classe Convert passar para a Parser para criar a tag tagide